### PR TITLE
fix parsing filter values

### DIFF
--- a/src/bin/analyze-remarks.rs
+++ b/src/bin/analyze-remarks.rs
@@ -42,6 +42,7 @@ struct Args {
     /// Optimization remark kinds that should be ignored.
     #[arg(
         long = "filter",
+        value_delimiter = ',',
         default_values = cargo_remark::DEFAULT_KIND_FILTER
     )]
     filter_kind: Vec<String>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,6 +49,7 @@ struct SharedArgs {
     /// Optimization remark kinds that should be ignored.
     #[arg(
         long = "filter",
+        value_delimiter = ',',
         default_values = cargo_remark::DEFAULT_KIND_FILTER
     )]
     filter_kind: Vec<String>,


### PR DESCRIPTION
Multiple values were parsed as a single string. Now they correctly use a comma to separate them as specificied in the readme.

Fixes #11